### PR TITLE
Update cors config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,13 +37,5 @@ module OrbitApiApp
     config.api_only = true
 
     config.time_zone = 'Tokyo'
-
-    # TODO: 本番環境でのCORSの設定必要
-    config.middleware.insert_before 0, Rack::Cors do
-      allow do
-        origins 'localhost:4000'
-        resource '*', :headers => :any, :methods => [:get, :post, :put, :delete, :options]
-      end
-    end
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,8 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    # TODO: Production環境では訂正
-    origins 'localhost:4000', 'https://orbit7.herokuapp.com/'
+    origins 'localhost:4000', 'https://the-orbit-app.com'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
本番用にcorsの設定をUpdate
現在httpsからだと
```
Mixed Content: The page at 'https://the-orbit-app.com/guests' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://52.69.76.248/api/signup'. This request has been blocked; the content must be served over HTTPS.
```
というエラーが起きるためhttp://the-orbit-app.com からでないとバックエンドへのリクエストが成功しませんが、今後アクセスはhttpsのみに限定する予定です。